### PR TITLE
add Write Arcknoledge from master to slave support

### DIFF
--- a/XantoI2C.cpp
+++ b/XantoI2C.cpp
@@ -59,13 +59,17 @@ void XantoI2C::clockPulse() {
 
 void XantoI2C::writeByte(uint8_t data_byte) {
   for (uint8_t i = 0; i < 8; i++) {
-    if (bitRead(data_byte, 7 - i)) {
+    writeBit(bitRead(data_byte, 7 - i));
+  }
+}
+
+void XantoI2C::writeBit(bool data_bit) {
+    if ( data_bit ) {
       sdaHi();
     } else {
       sdaLo();
     }
     clockPulse();
-  }
 }
 
 uint8_t XantoI2C::readBit() {
@@ -103,6 +107,14 @@ uint8_t XantoI2C::readAck() {
 uint8_t XantoI2C::readNack() {
   sdaHi();
   return readBit() == 1 ? 0 : 1;
+}
+
+void XantoI2C::writeAck() {
+  writeBit(false);
+}
+
+void XantoI2C::writeNack() {
+  writeBit(true);
 }
 
 /**

--- a/XantoI2C.h
+++ b/XantoI2C.h
@@ -67,7 +67,7 @@ class XantoI2C {
     /**
      * Write one bit of data to a slave
      */
-	void writeBit(bool data_bit);
+    void writeBit(bool data_bit);
 
     void sclHi();
     void sdaHi();

--- a/XantoI2C.h
+++ b/XantoI2C.h
@@ -64,6 +64,11 @@ class XantoI2C {
      */
     uint8_t readBit();
 
+    /**
+     * Write one bit of data to a slave
+     */
+	void writeBit(bool data_bit);
+
     void sclHi();
     void sdaHi();
     void sclLo();
@@ -118,6 +123,16 @@ class XantoI2C {
     * Return 0 if NACK was received, else 1
     */
     uint8_t readNack();
+
+    /**
+     * Write Acknowledge to a slave
+     */
+    void writeAck();
+
+    /**
+    * Write No Acknowledge to a slave
+    */
+    void writeNack();
 
     /**
      * Execute scenario: start, write, ack and stop


### PR DESCRIPTION
Hi!

conform to i2c/SMBus standard:

- in case of "write block" operation, ACKs is sent by the slave and read by the master.
- in case of "read block" operation, when slave response, ACKs/NACKs is sent by the *master* and received by the *slave*
( see: http://www.smbus.org/specs/smbus20.pdf, page 20, fig. 5-1 )

...but Xanto I2C seem not capable to send ACKs/NACKs by the master.

Therefore, I've added writeBit function (called also by writeByte for code reduction), and added writeAck and writeNack.

Thanks in advance for your merge.

Enjoy!

goodchip
